### PR TITLE
fix: disable switching buffer in file panel

### DIFF
--- a/lua/diffview/ui/panel.lua
+++ b/lua/diffview/ui/panel.lua
@@ -39,6 +39,7 @@ Panel.winopts = {
   relativenumber = false,
   number = false,
   list = false,
+  winfixbuf = true,
   winfixwidth = true,
   winfixheight = true,
   foldenable = false,


### PR DESCRIPTION
The `winfixbuf` options locks a window to a particular buffer. In this PR, I've enabled this option for the file panel, which prevents the user from accidentally opening a different buffer in the panel window.

Personally, I never want to open a different buffer in the file panel, but I'm not sure if this feature would be universally accepted, so maybe it should be made configurable.