### PR TITLE
jj: label single-change diffs with the description

### DIFF
--- a/lua/diffview/api/views/diff/diff_view.lua
+++ b/lua/diffview/api/views/diff/diff_view.lua
@@ -18,6 +18,14 @@ local logger = DiffviewGlobal.logger
 
 local M = {}
 
+local function rev_to_panel_name(adapter, rev_arg, left, right)
+  if adapter.rev_to_panel_name then
+    return adapter:rev_to_panel_name(rev_arg, left, right)
+  end
+
+  return rev_arg or adapter:rev_to_pretty_string(left, right)
+end
+
 ---@class FileData
 ---@field path string Path relative to git root.
 ---@field oldpath string|nil If the file has been renamed, this should be the old path, oterhwise nil.
@@ -67,7 +75,7 @@ function CDiffView:init(opt)
       adapter,
       self.files,
       self.path_args,
-      self.rev_arg or adapter:rev_to_pretty_string(opt.left, opt.right)
+      rev_to_panel_name(adapter, self.rev_arg, opt.left, opt.right)
     ),
   }))
 

--- a/lua/diffview/scene/views/diff/diff_view.lua
+++ b/lua/diffview/scene/views/diff/diff_view.lua
@@ -31,6 +31,14 @@ local M = {}
 
 local same_rev = lazy.access(rev_lib, "same_rev") --[[@as fun(a: Rev?, b: Rev?): boolean ]]
 
+local function rev_to_panel_name(adapter, rev_arg, left, right)
+  if adapter.rev_to_panel_name then
+    return adapter:rev_to_panel_name(rev_arg, left, right)
+  end
+
+  return rev_arg or adapter:rev_to_pretty_string(left, right)
+end
+
 ---@class DiffViewOptions
 ---@field show_untracked? boolean
 ---@field selected_file? string Path to the preferred initially selected file.
@@ -76,7 +84,7 @@ function DiffView:init(opt)
       self.adapter,
       self.files,
       self.path_args,
-      self.rev_arg or self.adapter:rev_to_pretty_string(self.left, self.right)
+      rev_to_panel_name(self.adapter, self.rev_arg, self.left, self.right)
     ),
   })
 
@@ -399,7 +407,7 @@ function DiffView:set_revs(new_rev_arg, opts)
   self.rev_arg = new_rev_arg
   self.left = new_left
   self.right = new_right
-  self.panel.rev_pretty_name = new_rev_arg
+  self.panel.rev_pretty_name = rev_to_panel_name(self.adapter, new_rev_arg, self.left, self.right)
 
   -- Migrate selection persistence to the new scope key.
   if self._selection_scope_key then
@@ -707,10 +715,6 @@ local update_files_impl = debounce.debounce_trailing(
     if new_left and new_right then
       self.left = new_left
       self.right = new_right
-
-      if not self.rev_arg then
-        self.panel.rev_pretty_name = self.adapter:rev_to_pretty_string(self.left, self.right)
-      end
     end
     perf:lap("refreshed revs")
 
@@ -727,6 +731,10 @@ local update_files_impl = debounce.debounce_trailing(
       end
       perf:lap("updated head rev")
     end
+
+    self.panel.rev_pretty_name =
+      rev_to_panel_name(self.adapter, self.rev_arg, self.left, self.right)
+    perf:lap("updated rev label")
 
     local index_stat = pl:stat(pl:join(self.adapter.ctx.dir, "index"))
 

--- a/lua/diffview/tests/functional/jj_adapter_spec.lua
+++ b/lua/diffview/tests/functional/jj_adapter_spec.lua
@@ -570,6 +570,74 @@ describe("diffview.vcs.adapters.jj", function()
       end
     end)
 
+    describe("rev_to_panel_name", function()
+      it("includes the description for a single-change range", function()
+        if not jj_available() then
+          pending("jj not installed")
+          return
+        end
+
+        repo.write("file.txt", "first\n")
+        repo.jj({ "describe", "-m", "initial" })
+        repo.jj({ "new" })
+        repo.write("file.txt", "second\n")
+        repo.jj({ "describe", "-m", "update file" })
+
+        local adapter = repo.adapter()
+        local parent_hash =
+          run({ "jj", "show", "-T", "parents.first().commit_id()", "@", "--no-patch" }, repo.dir)
+        local commit_hash = run({ "jj", "show", "-T", "commit_id", "@", "--no-patch" }, repo.dir)
+        local left = adapter.Rev(RevType.COMMIT, parent_hash)
+        local right = adapter.Rev(RevType.COMMIT, commit_hash)
+
+        eq(left:abbrev() .. ".." .. right:abbrev(), adapter:rev_to_pretty_string(left, right))
+        eq(
+          "update file",
+          adapter:rev_to_panel_name(left:abbrev() .. ".." .. right:abbrev(), left, right)
+        )
+
+        local non_parent = adapter.Rev(RevType.COMMIT, string.rep("1", 40))
+        eq("main..@", adapter:rev_to_panel_name("main..@", non_parent, right))
+      end)
+
+      it("uses the current change description for a default no-arg diff", function()
+        if not jj_available() then
+          pending("jj not installed")
+          return
+        end
+
+        repo.write("file.txt", "first\n")
+        repo.jj({ "describe", "-m", "initial" })
+        repo.jj({ "new" })
+        repo.write("file.txt", "second\n")
+        repo.jj({ "describe", "-m", "current change" })
+
+        local adapter = repo.adapter()
+        local left, right = adapter:parse_revs(nil, {})
+
+        eq(RevType.COMMIT, left.type)
+        eq(RevType.LOCAL, right.type)
+        eq("current change", adapter:rev_to_panel_name(nil, left, right))
+      end)
+
+      it("falls back for null-tree ranges", function()
+        if not jj_available() then
+          pending("jj not installed")
+          return
+        end
+
+        repo.write("file.txt", "first\n")
+        repo.jj({ "describe", "-m", "initial" })
+
+        local adapter = repo.adapter()
+        local commit_hash = run({ "jj", "show", "-T", "commit_id", "@", "--no-patch" }, repo.dir)
+        local left = adapter.Rev.new_null_tree()
+        local right = adapter.Rev(RevType.COMMIT, commit_hash)
+
+        eq("root range", adapter:rev_to_panel_name("root range", left, right))
+      end)
+    end)
+
     describe("tracked_files", function()
       it(
         "lists modified, added, and deleted files",

--- a/lua/diffview/tests/functional/set_revs_spec.lua
+++ b/lua/diffview/tests/functional/set_revs_spec.lua
@@ -134,6 +134,26 @@ describe("DiffView:set_revs", function()
       eq("ccc333..ddd444", view.panel.rev_pretty_name)
     end)
 
+    it("uses adapter panel labels when available", function()
+      local old_left = make_rev("aaa111")
+      local old_right = make_rev("bbb222")
+      local new_left = make_rev("ccc333")
+      local new_right = make_rev("ddd444")
+
+      local adapter = make_adapter({
+        ["ccc333..ddd444"] = { new_left, new_right },
+      })
+      adapter.rev_to_panel_name = function(_, rev_arg, left, right)
+        return table.concat({ "label", rev_arg, left.commit, right.commit }, ":")
+      end
+
+      local view = make_view(adapter, old_left, old_right, "aaa111..bbb222")
+
+      view:set_revs("ccc333..ddd444")
+
+      eq("label:ccc333..ddd444:ccc333:ddd444", view.panel.rev_pretty_name)
+    end)
+
     it("does nothing when parse_revs fails", function()
       local left = make_rev("aaa111")
       local right = make_rev("bbb222")

--- a/lua/diffview/vcs/adapter.lua
+++ b/lua/diffview/vcs/adapter.lua
@@ -651,6 +651,18 @@ function VCSAdapter:rev_to_pretty_string(left, right)
   return nil
 end
 
+---Convert revs to the display-only label shown in the file panel.
+---Unlike rev_to_pretty_string the result need not be parseable as a rev.
+---The default prefers the user's rev_arg; adapters may substitute a
+---friendlier label.
+---@param rev_arg string?
+---@param left Rev
+---@param right Rev
+---@return string|nil
+function VCSAdapter:rev_to_panel_name(rev_arg, left, right)
+  return rev_arg or self:rev_to_pretty_string(left, right)
+end
+
 ---Check if any of the given revs are LOCAL.
 ---@param left Rev
 ---@param right Rev

--- a/lua/diffview/vcs/adapters/jj/init.lua
+++ b/lua/diffview/vcs/adapters/jj/init.lua
@@ -563,6 +563,72 @@ function JjAdapter:parse_revs(rev_arg, opt)
   return left, right
 end
 
+---@param left Rev
+---@param right Rev
+---@return string|nil
+function JjAdapter:single_change_subject(left, right)
+  if not (left and left.commit and right) then
+    return
+  end
+
+  if left.commit == JjRev.NULL_TREE_SHA then
+    return
+  end
+
+  local right_rev
+  if right.type == RevType.LOCAL then
+    right_rev = "@"
+  elseif right.commit and right.commit ~= JjRev.NULL_TREE_SHA then
+    right_rev = right.commit
+  else
+    return
+  end
+
+  local out, code = self:exec_sync(
+    utils.vec_join(
+      self:args(),
+      "--ignore-working-copy",
+      "log",
+      "--no-graph",
+      "-r",
+      right_rev,
+      "-T",
+      [[parents.first().commit_id() ++ "\x1f" ++ description.first_line() ++ "\n"]]
+    ),
+    {
+      cwd = self.ctx.toplevel,
+      retry = 2,
+      silent = true,
+      log_opt = { label = "JjAdapter:single_change_subject()" },
+    }
+  )
+
+  if code ~= 0 or not out[1] then
+    return
+  end
+
+  local parent, subject = vim.trim(out[1]):match("^([^\31]*)\31(.*)$")
+  if parent ~= left.commit then
+    return
+  end
+
+  subject = vim.trim(subject or "")
+  return subject ~= "" and subject or nil
+end
+
+---@param rev_arg string?
+---@param left Rev
+---@param right Rev
+---@return string|nil
+function JjAdapter:rev_to_panel_name(rev_arg, left, right)
+  local subject = self:single_change_subject(left, right)
+  if subject then
+    return subject
+  end
+
+  return rev_arg or self:rev_to_pretty_string(left, right)
+end
+
 ---@param rev_arg string?
 ---@param left Rev
 ---@param right Rev


### PR DESCRIPTION
Diffview currently uses the raw rev argument as the file-panel "Showing changes for" label whenever :DiffviewOpen is called with an explicit revision argument.  Since with jj you are running `jj desc` as the work progresses, the label can instead show the description of the change.  This needs a new hook rev_to_panel_name because the existing rev_to_pretty_string is used as parsable rev text in other code paths (such as opening history), so rev_to_pretty_string must keep the string as a valid revision.

The new rev_to_panel_name hook is added and is identical in behavior to the existing code for all other adapters besides jj.  For jj, we detect if the current diff is a single change and if so show the description.  Although, now that I think about it, maybe we could expand and list all the changes in the diff?  Well, this is a good first step.
