### PR TITLE
fix(path): use os.getenv instead of vim.env in PathLib:expand

### DIFF
--- a/lua/diffview/path.lua
+++ b/lua/diffview/path.lua
@@ -340,7 +340,7 @@ function PathLib:expand(path)
   for i = idx, #segments do
     local env_var = segments[i]:match("^%$(%S+)$")
     if env_var then
-      local value = vim.env[env_var]
+      local value = os.getenv(env_var)
       if value ~= nil then
         segments[i] = value
       end


### PR DESCRIPTION
  - PathLib:expand (and therefore PathLib:absolute) read environment variables via vim.env[env_var], whose __index is backed by
  Vimscript's getenv() — a call that requires Neovim's main/textlock context.
  - PathLib:absolute is diffview's general-purpose path-resolution helper and gets called while processing paths returned from git
  subprocess output, which runs inside libuv job/process callbacks (fast-event context). On Neovim 0.10+ this throws an E5560-class
  error ("Vimscript function must not be called in a lua loop callback") for any path containing a literal $VAR segment.
  - Replaced vim.env[env_var] with os.getenv(env_var) — a plain Lua/C call with no dependency on the main loop, safe from any context,
  and a drop-in equivalent for this read-only lookup.
