### PR TITLE
fix(diff): invalidate stage buffers when a newly added file is unstaged

### DIFF
--- a/lua/diffview/scene/file_entry.lua
+++ b/lua/diffview/scene/file_entry.lua
@@ -192,9 +192,13 @@ function FileEntry:validate_stage_buffers(stat)
           local is_modified = vim.bo[f.bufnr].modified
 
           if f.blob_hash then
+            -- `new_hash` is nil when the path no longer has a stage-0 blob at
+            -- all (e.g. a newly added file that was unstaged, leaving it
+            -- untracked). That is a content change like any other: the buffer
+            -- still shows the old staged blob and must be invalidated.
             local new_hash = self.adapter:file_blob_hash(f.path)
 
-            if new_hash and new_hash ~= f.blob_hash then
+            if new_hash ~= f.blob_hash then
               if is_modified then
                 utils.warn(
                   (

--- a/lua/diffview/scene/views/diff/diff_view.lua
+++ b/lua/diffview/scene/views/diff/diff_view.lua
@@ -828,6 +828,25 @@ local update_files_impl = debounce.debounce_trailing(
               )
             end
 
+            -- A status change can flip a side's nulled state even when the
+            -- revs are identical (e.g. unstaging a newly added file: the
+            -- working entry goes "M" -> "?" and its a-side no longer has a
+            -- stage-0 blob). The NOOP path only copies `status` onto the old
+            -- entry; the Files' `nulled` flags are fixed at construction, so
+            -- the old a-side would keep showing — and try to reload — a blob
+            -- that no longer exists. Replace the entry instead.
+            if not replace_noop then
+              for _, sym in ipairs({ "a", "b", "c", "d" }) do
+                local of = old_file.layout:get_file_for(sym)
+                local nf = new_file.layout:get_file_for(sym)
+
+                if (of and of.nulled or false) ~= (nf and nf.nulled or false) then
+                  replace_noop = true
+                  break
+                end
+              end
+            end
+
             if replace_noop then
               if self.panel.cur_file == old_file then
                 self.panel:set_cur_file(new_file)

--- a/lua/diffview/vcs/adapters/git/init.lua
+++ b/lua/diffview/vcs/adapters/git/init.lua
@@ -1843,6 +1843,11 @@ end
 ---@param rev_arg string?
 ---@return string?
 function GitAdapter:file_blob_hash(path, rev_arg)
+  -- Empty output with exit code 0 is a real outcome, not a failure: the path
+  -- has no blob at that rev (e.g. a newly added file that was unstaged no
+  -- longer exists in the index at all). `fail_on_empty` would burn retries
+  -- and spam the log for it; instead let the empty result through and map it
+  -- to nil so callers can distinguish "no blob" from a blob hash.
   local out, code = self:exec_sync({
     "rev-parse",
     "--revs-only",
@@ -1850,10 +1855,9 @@ function GitAdapter:file_blob_hash(path, rev_arg)
   }, {
     cwd = self.ctx.toplevel,
     retry = 2,
-    fail_on_empty = true,
   })
 
-  if code ~= 0 then
+  if code ~= 0 or not out[1] or vim.trim(out[1]) == "" then
     return
   end
 


### PR DESCRIPTION
## Problem

Unstaging a newly added file (status `AM` → `??`) while its diff is open leaves the view permanently out of sync. Depending on timing, one of two symptoms appears:

1. **Stale diff** — the `:0:` (index) side keeps showing the old staged content on every refresh. `R` / `:DiffviewRefresh` doesn't help; only closing the tab and reopening does.
2. **Crash chain** — `Failed to create diff buffer ':0:<path>'` followed by `E5560: nvim_buf_is_valid must not be called in a fast event context`, when the stage buffer is (re)created after the blob has left the index.

Which symptom you get depends on whether `blob_hash` was successfully captured when the stage buffer was created.

## Root cause

Three stacked defects, all downstream of the same event — the path leaving the index entirely (unlike unstaging a *tracked* file, which merely resets the stage-0 blob back to the HEAD blob):

1. `GitAdapter:file_blob_hash()` used `fail_on_empty = true`, so the legitimate "path has no blob at this rev" answer (empty output, exit 0) was treated as a retryable job failure: 3 retries, error log spam on every refresh, and a `nil` return indistinguishable from a real failure.
2. `FileEntry:validate_stage_buffers()` gated disposal on `if new_hash and new_hash ~= f.blob_hash`, so a `nil` hash silently skipped invalidation and the stale buffer survived every refresh.
3. The NOOP branch of `DiffView:update_files()` keeps an entry when its path and revs are unchanged, copying only `status` onto it. But each side's `nulled` flag is fixed at construction, and it derives from the status (`Diff2.should_null`): the `M` → `?` transition must flip the a-side to nulled. The kept entry instead retained a live a-side pointing at a blob that no longer exists — the source of both the stale buffer and the failed reload.

## Fix

- `file_blob_hash()`: drop `fail_on_empty`; map empty output to `nil` explicitly. "No blob at this rev" is a real answer, not a failure — this also removes the retry storm and log spam.
- `validate_stage_buffers()`: treat a `nil` new hash as a content change and dispose the buffer (the unmodified-buffer guard is unchanged).
- `update_files()` NOOP branch: force entry replacement when any side's `nulled` state would change, so the a-side of a now-untracked file renders as a proper null buffer instead of attempting to load a gone blob.

## Repro

With a Diffview tab open the whole time:

1. Create a new file (not in HEAD) with some content.
2. `:DiffviewOpen`, select the file — left side is empty (null buffer), right side is the working tree file, as expected for an untracked file.
3. `git add` the file, then edit it further in the working tree.
4. View the file again — left side now shows the staged version, right side the working tree. Still correct.
5. `git reset` the file (it becomes untracked again).
6. View the file — **left side still shows the staged version**, even though no staged version exists anymore. Expected: left side empty again, as in step 2. Refreshing (`R` / `:DiffviewRefresh`) doesn't help; only closing the tab and reopening does.

** Full disclosure**: This PR was created with AI-assistance. The bug was found, reproduced and flagged by a human. I'm one of those silly web devs, don't take my lua-based PR on face value. :)