### PR TITLE
fix(highlight): avoid leaking diff syntax into active buffers

### DIFF
--- a/lua/diffview/hl.lua
+++ b/lua/diffview/hl.lua
@@ -558,12 +558,10 @@ function M.update_diff_hl()
 end
 
 function M.setup()
-  -- Ensure diff highlights are defined by loading the diff syntax if needed.
-  -- Some colorschemes don't set diffAdded/diffRemoved/diffChanged until the
-  -- diff filetype is encountered.
-  if vim.fn.hlexists("diffAdded") == 0 then
-    vim.cmd("runtime! syntax/diff.vim")
-  end
+  -- Provide standard diff fallbacks without loading buffer-local syntax.
+  M.hi_link("diffAdded", "Added", { default = true })
+  M.hi_link("diffRemoved", "Removed", { default = true })
+  M.hi_link("diffChanged", "Changed", { default = true })
 
   for name, v in pairs(M.get_hl_groups()) do
     v = vim.tbl_extend("force", v, { default = true })

--- a/lua/diffview/tests/functional/highlight_spec.lua
+++ b/lua/diffview/tests/functional/highlight_spec.lua
@@ -1,0 +1,32 @@
+local api = vim.api
+
+describe("highlight setup", function()
+  it("defines diff fallbacks without loading diff syntax", function()
+    assert.equals(0, vim.fn.hlexists("diffAdded"))
+    api.nvim_buf_set_lines(0, 0, -1, false, {
+      "- unchanged markdown",
+      "+ unchanged markdown",
+    })
+
+    require("diffview.hl").setup()
+
+    assert.is_nil(vim.b.current_syntax)
+    assert.equals("", vim.fn.synIDattr(vim.fn.synID(1, 1, true), "name"))
+    assert.equals("", vim.fn.synIDattr(vim.fn.synID(2, 1, true), "name"))
+    assert.equals("Added", api.nvim_get_hl(0, { name = "diffAdded" }).link)
+    assert.equals("Removed", api.nvim_get_hl(0, { name = "diffRemoved" }).link)
+    assert.equals("Changed", api.nvim_get_hl(0, { name = "diffChanged" }).link)
+  end)
+
+  it("preserves existing diff highlight groups", function()
+    api.nvim_set_hl(0, "diffAdded", { fg = 0x112233 })
+    api.nvim_set_hl(0, "diffRemoved", { fg = 0x223344 })
+    api.nvim_set_hl(0, "diffChanged", { fg = 0x334455 })
+
+    require("diffview.hl").setup()
+
+    assert.equals(0x112233, api.nvim_get_hl(0, { name = "diffAdded" }).fg)
+    assert.equals(0x223344, api.nvim_get_hl(0, { name = "diffRemoved" }).fg)
+    assert.equals(0x334455, api.nvim_get_hl(0, { name = "diffChanged" }).fg)
+  end)
+end)


### PR DESCRIPTION
When Diffview initializes and `diffAdded` is undefined, it sources Neovim's `syntax/diff.vim` in the current buffer.

In Tree-sitter-only setups, `b:current_syntax` can be unset, so this installs buffer-local `^+` and `^-` syntax matches.

Unchanged files may then display addition and deletion colors based only on their line prefixes.

- Replace syntax-file sourcing with default highlight links
- Preserve user-defined diff highlight groups
- Add regression coverage for buffer contamination
