### PR TITLE
feat: fold unchanged inline diff regions

### DIFF
--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -1173,6 +1173,14 @@ view.inline                                     *diffview-config-view.inline*
                 unchanged, only the foreground colouring of the deleted
                 text is affected.
 
+            {fold_unchanged} (boolean)
+                Fold unchanged regions in the `diff1_inline` layout using
+                expression folds. Default: `false`. The number of visible
+                context lines follows `context:N` in |'diffopt'|, defaulting
+                to 6 when omitted. Pure-deletion anchors remain unfolded so
+                their deleted virtual lines stay visible. |view.foldlevel|
+                controls the initial fold level.
+
 view.file_history.pin_local                     *diffview-config-view.file_history.pin_local*
         Type: `boolean`, Default: `false`
 

--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -1178,8 +1178,8 @@ view.inline                                     *diffview-config-view.inline*
                 expression folds. Default: `false`. The number of visible
                 context lines follows `context:N` in |'diffopt'|, defaulting
                 to 6 when omitted. Pure-deletion anchors remain unfolded so
-                their deleted virtual lines stay visible. |view.foldlevel|
-                controls the initial fold level.
+                their deleted virtual lines stay visible. The initial fold
+                level is controlled by |diffview-config-view.foldlevel|.
 
 view.file_history.pin_local                     *diffview-config-view.file_history.pin_local*
         Type: `boolean`, Default: `false`

--- a/doc/diffview_defaults.txt
+++ b/doc/diffview_defaults.txt
@@ -133,6 +133,9 @@ DEFAULT CONFIG                                  *diffview.defaults*
         -- so they read like the rest of the buffer. No-op when no parser
         -- is attached for the buffer's filetype.
         deletion_treesitter = true,
+        -- Fold unchanged regions using expression folds. The visible context
+        -- follows `context:N` in 'diffopt' (6 lines when omitted).
+        fold_unchanged = false,
       },
     },
     file_panel = {

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -409,11 +409,13 @@ M.defaults = {
     ---@field style DiffviewInlineStyle
     ---@field deletion_highlight DiffviewInlineDeletionHighlight
     ---@field deletion_treesitter boolean
+    ---@field fold_unchanged boolean
 
     ---@class DiffviewInlineConfig.user
     ---@field style? DiffviewInlineStyle Rendering style for `diff1_inline`. "unified" shows old lines as virt_lines above; "overleaf" renders deletions as inline strikethrough virt_text.
     ---@field deletion_highlight? DiffviewInlineDeletionHighlight Extent of the `DiffDelete` background on deleted virt_lines: `"text"` covers only the deleted chars, `"full_width"` pads to the row, `"hanging"` covers everything except the leading indent.
     ---@field deletion_treesitter? boolean Layer tree-sitter syntax highlights over the deleted virt_lines so they read like the rest of the buffer. Falls back transparently when no parser is attached.
+    ---@field fold_unchanged? boolean Fold unchanged regions in `diff1_inline`, using the context from 'diffopt'.
     -- Options specific to the `diff1_inline` layout.
     inline = {
       -- Rendering style. "unified": proper unified diff -- old lines shown
@@ -432,6 +434,9 @@ M.defaults = {
       -- they read like the rest of the buffer. No-op when no parser is
       -- attached for the buffer's filetype.
       deletion_treesitter = true,
+      -- Fold unchanged regions with 'foldmethod' set to "expr". The number
+      -- of visible context lines follows the `context:N` value in 'diffopt'.
+      fold_unchanged = false,
     },
   },
 
@@ -1648,6 +1653,9 @@ function M.setup(user_config)
   )
   validate.boolean(view.inline, "deletion_treesitter", d.view.inline.deletion_treesitter, {
     path = "view.inline.deletion_treesitter",
+  })
+  validate.boolean(view.inline, "fold_unchanged", d.view.inline.fold_unchanged, {
+    path = "view.inline.fold_unchanged",
   })
 
   -- file_panel

--- a/lua/diffview/scene/inline_diff.lua
+++ b/lua/diffview/scene/inline_diff.lua
@@ -1206,6 +1206,11 @@ end
 ---@type table<integer, integer[][]>
 M._hunks_by_buf = {}
 
+-- Per-buffer visible ranges for expression folds in the inline layout. Each
+-- range is a 1-indexed inclusive pair covering a hunk and its context lines.
+---@type table<integer, { [1]: integer, [2]: integer }[]>
+local fold_ranges_by_buf = {}
+
 -- Per-buffer cache of tree-sitter captures for the old side. Survives
 -- `M.clear`/`M.render` so `_repaint`-style flows (where `old_lines` is held
 -- by the caller and reused unchanged) skip the parse on every redraw. The
@@ -1268,6 +1273,7 @@ local function register_cache_cleanup(bufnr)
     once = true,
     callback = function(args)
       M._hunks_by_buf[args.buf] = nil
+      fold_ranges_by_buf[args.buf] = nil
       M._captures_by_buf[args.buf] = nil
       -- The hosting windows may still be valid (e.g. `:bdelete`
       -- switches them to an alternate buffer rather than closing
@@ -1548,6 +1554,7 @@ function M.clear(bufnr)
   -- render pass to register a duplicate autocmd.
   if bufnr then
     M._hunks_by_buf[bufnr] = nil
+    fold_ranges_by_buf[bufnr] = nil
   end
 end
 
@@ -1650,6 +1657,65 @@ end
 ---@return integer[][]?
 function M.get_hunks(bufnr)
   return M._hunks_by_buf[bufnr]
+end
+
+-- Cache the ranges that must remain visible around inline hunks. Pure
+-- deletions use their extmark anchor as the visible line so folding cannot
+-- hide the deleted virtual lines.
+---@param bufnr integer
+---@param context integer
+function M.update_fold_ranges(bufnr, context)
+  local hunks = M._hunks_by_buf[bufnr]
+  if not hunks or #hunks == 0 then
+    fold_ranges_by_buf[bufnr] = nil
+    return
+  end
+
+  local line_count = api.nvim_buf_line_count(bufnr)
+  local ranges = {}
+
+  for _, h in ipairs(hunks) do
+    local first = math.max(1, h[3])
+    local last = h[4] > 0 and first + h[4] - 1 or first
+    first = math.max(1, first - context)
+    last = math.min(line_count, last + context)
+
+    local previous = ranges[#ranges]
+    if previous and first <= previous[2] + 1 then
+      previous[2] = math.max(previous[2], last)
+    else
+      ranges[#ranges + 1] = { first, last }
+    end
+  end
+
+  fold_ranges_by_buf[bufnr] = ranges
+end
+
+-- Return fold level 0 for hunk context and 1 for unchanged lines. The ranges
+-- are sorted, so a binary search keeps foldexpr evaluation cheap for files
+-- with many hunks.
+---@param lnum integer
+---@return integer
+function M.foldexpr(lnum)
+  local ranges = fold_ranges_by_buf[api.nvim_get_current_buf()]
+  if not ranges then
+    return 0
+  end
+
+  local low, high = 1, #ranges
+  while low <= high do
+    local middle = math.floor((low + high) / 2)
+    local range = ranges[middle]
+    if lnum < range[1] then
+      high = middle - 1
+    elseif lnum > range[2] then
+      low = middle + 1
+    else
+      return 0
+    end
+  end
+
+  return 1
 end
 
 -- Find the row of the last hunk strictly before `cursor_row` (0-indexed).

--- a/lua/diffview/scene/layouts/diff_1_inline.lua
+++ b/lua/diffview/scene/layouts/diff_1_inline.lua
@@ -80,6 +80,7 @@ local INLINE_FOLDEXPR = "v:lua.require'diffview.scene.inline_diff'.foldexpr(v:ln
 ---@class Diff1Inline : Diff1
 ---@field a_file vcs.File? Old-side file used only to compute the diff (never rendered in a window).
 ---@field _cached_old_lines string[]? Old-side content captured on first render; reused by repaints so each keystroke-level refresh doesn't re-fetch from disk.
+---@field _fold_bufnr integer? Buffer whose expression folds have been initialized in the inline window.
 ---@field _render_generation integer Bumped on every state transition that invalidates in-flight render work: file swap (`use_entry`), render teardown (`teardown_render`, which covers `destroy` and `FileEntry:convert_layout`), and recreate (`create`). Async passes capture the value at entry and bail when it changes mid-flight, so a stale `_load_old_lines` callback can't overwrite `_cached_old_lines` for a file the user has navigated past or render onto a buffer the view no longer owns. Also covers cached-instance reuse: `StandardView` keeps one layout per class and re-runs `create` on the same instance after a prior `destroy`, so a sticky destroyed flag would block reuse; the monotonic counter does not.
 ---@field _repaint_bufnr integer? Buffer id the repaint autocmds are attached to (nil when no autocmds are installed).
 ---@field _repaint_debounced CancellableFn? Trailing-edge debounced `_repaint` used for the insert-mode `TextChangedI` hook.
@@ -518,11 +519,20 @@ function Diff1Inline:_update_folds()
 
   local winid = self.b.id
   pcall(api.nvim_win_call, winid, function()
-    vim.wo.foldmethod = "expr"
-    vim.wo.foldexpr = INLINE_FOLDEXPR
-    vim.wo.foldenable = true
-    vim.wo.foldlevel = conf.view.foldlevel
-    vim.cmd("silent! normal! zX")
+    local configured = self._fold_bufnr == bufnr
+      and vim.wo.foldmethod == "expr"
+      and vim.wo.foldexpr == INLINE_FOLDEXPR
+    if not configured then
+      vim.wo.foldmethod = "expr"
+      vim.wo.foldexpr = INLINE_FOLDEXPR
+      vim.wo.foldenable = true
+      vim.wo.foldlevel = conf.view.foldlevel
+      self._fold_bufnr = bufnr
+    else
+      -- Reassigning 'foldexpr' invalidates expression folds without resetting
+      -- folds the user manually opened or closed, unlike zX/'foldlevel'.
+      vim.wo.foldexpr = INLINE_FOLDEXPR
+    end
   end)
 end
 
@@ -759,6 +769,7 @@ function Diff1Inline:teardown_render()
   end
   self._repaint_bufnr = nil
   self._cached_old_lines = nil
+  self._fold_bufnr = nil
   if self.b and self.b.file and self.b.file.bufnr then
     inline_diff.detach(self.b.file.bufnr)
   end

--- a/lua/diffview/scene/layouts/diff_1_inline.lua
+++ b/lua/diffview/scene/layouts/diff_1_inline.lua
@@ -75,6 +75,8 @@ local INSERT_REPAINT_DEBOUNCE_MS = 150
 ---into a single re-emit so the per-resize-step diff cost doesn't pile up.
 local RESIZE_REPAINT_DEBOUNCE_MS = 100
 
+local INLINE_FOLDEXPR = "v:lua.require'diffview.scene.inline_diff'.foldexpr(v:lnum)"
+
 ---@class Diff1Inline : Diff1
 ---@field a_file vcs.File? Old-side file used only to compute the diff (never rendered in a window).
 ---@field _cached_old_lines string[]? Old-side content captured on first render; reused by repaints so each keystroke-level refresh doesn't re-fetch from disk.
@@ -406,6 +408,7 @@ function Diff1Inline:_repaint()
   -- `_repaint`.
   local new_lines = self.b.file.nulled and {} or api.nvim_buf_get_lines(bufnr, 0, -1, false)
   inline_diff.render(bufnr, old_lines, new_lines, render_opts(self.b.id))
+  self:_update_folds()
 end
 
 ---Install buffer-scoped autocmds that repaint on edits. Fires on any
@@ -503,6 +506,26 @@ local function register_repaint_autocmds(self, bufnr)
   end
 end
 
+function Diff1Inline:_update_folds()
+  local conf = config.get_config()
+  if not conf.view.inline.fold_unchanged then
+    return
+  end
+
+  local bufnr = self.b.file.bufnr --[[@as integer ]]
+  local context = tonumber(vim.o.diffopt:match("context:(%d+)")) or 6
+  inline_diff.update_fold_ranges(bufnr, context)
+
+  local winid = self.b.id
+  pcall(api.nvim_win_call, winid, function()
+    vim.wo.foldmethod = "expr"
+    vim.wo.foldexpr = INLINE_FOLDEXPR
+    vim.wo.foldenable = true
+    vim.wo.foldlevel = conf.view.foldlevel
+    vim.cmd("silent! normal! zX")
+  end)
+end
+
 ---Install window-scoped state once the b buffer is visible: turn off
 ---native diff mode (so it doesn't fight the extmark rendering), scope the
 ---namespace to this window (issue #156), and register repaint autocmds.
@@ -526,8 +549,13 @@ function Diff1Inline:_install_window_hooks()
   pcall(api.nvim_set_option_value, "diff", false, { win = winid })
   pcall(api.nvim_set_option_value, "scrollbind", false, { win = winid })
   pcall(api.nvim_set_option_value, "cursorbind", false, { win = winid })
-  pcall(api.nvim_set_option_value, "foldmethod", "manual", { win = winid })
-  pcall(api.nvim_set_option_value, "foldenable", false, { win = winid })
+
+  if config.get_config().view.inline.fold_unchanged then
+    self:_update_folds()
+  else
+    pcall(api.nvim_set_option_value, "foldmethod", "manual", { win = winid })
+    pcall(api.nvim_set_option_value, "foldenable", false, { win = winid })
+  end
 
   inline_diff.attach_to_window(bufnr, winid)
   register_repaint_autocmds(self, bufnr)

--- a/lua/diffview/tests/functional/config_options_spec.lua
+++ b/lua/diffview/tests/functional/config_options_spec.lua
@@ -264,6 +264,42 @@ describe("view.inline.deletion_treesitter", function()
   end)
 end)
 
+describe("view.inline.fold_unchanged", function()
+  local original
+  local utils = require("diffview.utils")
+  local orig_err
+  local orig_warn
+
+  before_each(function()
+    original = vim.deepcopy(config.get_config())
+    orig_err = utils.err
+    orig_warn = utils.warn
+    utils.err = function() end
+    utils.warn = function() end
+  end)
+
+  after_each(function()
+    config.setup(original)
+    utils.err = orig_err
+    utils.warn = orig_warn
+  end)
+
+  it("defaults to false", function()
+    local conf = setup_with({})
+    assert.equals(false, conf.view.inline.fold_unchanged)
+  end)
+
+  it("accepts true", function()
+    local conf = setup_with({ view = { inline = { fold_unchanged = true } } })
+    assert.equals(true, conf.view.inline.fold_unchanged)
+  end)
+
+  it("rejects non-boolean values and falls back to the default", function()
+    local conf = setup_with({ view = { inline = { fold_unchanged = "yep" } } })
+    assert.equals(false, conf.view.inline.fold_unchanged)
+  end)
+end)
+
 describe("file_history_panel.log_options.jj", function()
   local original
 

--- a/lua/diffview/tests/functional/inline_diff_spec.lua
+++ b/lua/diffview/tests/functional/inline_diff_spec.lua
@@ -1176,6 +1176,32 @@ describe("diffview.scene.inline_diff", function()
     end)
   end)
 
+  describe("expression folds", function()
+    it("keeps a pure-deletion anchor and its context unfolded", function()
+      local old = {}
+      for i = 1, 20 do
+        old[i] = "line " .. i
+      end
+
+      local new = vim.deepcopy(old)
+      table.remove(new, 10)
+      local bufnr = fresh_buf(new)
+      inline_diff.render(bufnr, old, new)
+      inline_diff.update_fold_ranges(bufnr, 2)
+
+      api.nvim_buf_call(bufnr, function()
+        assert.equals(1, inline_diff.foldexpr(1))
+        for lnum = 7, 11 do
+          assert.equals(0, inline_diff.foldexpr(lnum))
+        end
+        assert.equals(1, inline_diff.foldexpr(19))
+      end)
+
+      local deleted = virt_line_counts(extmarks(bufnr))
+      assert.are.same({ { row = 8, count = 1, above = false } }, deleted)
+    end)
+  end)
+
   describe("helpers", function()
     local h = inline_diff._test
 

--- a/lua/diffview/tests/functional/layouts_spec.lua
+++ b/lua/diffview/tests/functional/layouts_spec.lua
@@ -1812,6 +1812,76 @@ describe("diffview.scene.layouts.diff_1_inline diffopt forwarding", function()
   end)
 end)
 
+describe("diffview.scene.layouts.diff_1_inline folding", function()
+  local Diff1Inline = require("diffview.scene.layouts.diff_1_inline").Diff1Inline
+  local config = require("diffview.config")
+  local inline_diff = require("diffview.scene.inline_diff")
+  local api = vim.api
+
+  it("keeps a pure-deletion anchor outside expression folds", function()
+    local original_config = vim.deepcopy(config.get_config())
+    local original_diffopt = vim.deepcopy(vim.opt.diffopt:get())
+    local old = {}
+    for i = 1, 20 do
+      old[i] = "line " .. i
+    end
+    local new = vim.deepcopy(old)
+    table.remove(new, 10)
+
+    local bufnr = api.nvim_create_buf(false, true)
+    api.nvim_buf_set_lines(bufnr, 0, -1, false, new)
+    local winid = api.nvim_open_win(bufnr, false, {
+      relative = "editor",
+      row = 1,
+      col = 1,
+      width = 40,
+      height = 10,
+    })
+    local inst = setmetatable({
+      b = {
+        id = winid,
+        file = {
+          bufnr = bufnr,
+          is_valid = function()
+            return true
+          end,
+        },
+        is_valid = function()
+          return true
+        end,
+      },
+    }, { __index = Diff1Inline })
+
+    local ok, err = pcall(function()
+      local diffopt = vim.tbl_filter(function(option)
+        return not option:match("^context:")
+      end, original_diffopt)
+      diffopt[#diffopt + 1] = "context:2"
+      vim.opt.diffopt = diffopt
+      config.setup({ view = { foldlevel = 0, inline = { fold_unchanged = true } } })
+
+      inline_diff.render(bufnr, old, new)
+      inst:_install_window_hooks()
+
+      api.nvim_win_call(winid, function()
+        assert.equals("expr", vim.wo.foldmethod)
+        assert.equals(1, vim.fn.foldclosed(1))
+        assert.equals(-1, vim.fn.foldclosed(9))
+      end)
+    end)
+
+    inst:teardown_render()
+    pcall(api.nvim_win_close, winid, true)
+    pcall(api.nvim_buf_delete, bufnr, { force = true })
+    vim.opt.diffopt = original_diffopt
+    config.setup(original_config)
+
+    if not ok then
+      error(err)
+    end
+  end)
+end)
+
 describe("diffview.layout.set_file_for", function()
   it("sets the file on the window and tags it with the symbol", function()
     local stored_file

--- a/lua/diffview/tests/functional/layouts_spec.lua
+++ b/lua/diffview/tests/functional/layouts_spec.lua
@@ -1818,7 +1818,7 @@ describe("diffview.scene.layouts.diff_1_inline folding", function()
   local inline_diff = require("diffview.scene.inline_diff")
   local api = vim.api
 
-  it("keeps a pure-deletion anchor outside expression folds", function()
+  it("keeps deletion anchors visible and preserves manual opens on repaint", function()
     local original_config = vim.deepcopy(config.get_config())
     local original_diffopt = vim.deepcopy(vim.opt.diffopt:get())
     local old = {}
@@ -1867,6 +1867,14 @@ describe("diffview.scene.layouts.diff_1_inline folding", function()
         assert.equals("expr", vim.wo.foldmethod)
         assert.equals(1, vim.fn.foldclosed(1))
         assert.equals(-1, vim.fn.foldclosed(9))
+
+        api.nvim_win_set_cursor(winid, { 1, 0 })
+        vim.cmd("normal! zo")
+        assert.equals(-1, vim.fn.foldclosed(1))
+
+        inst._cached_old_lines = old
+        inst:_repaint()
+        assert.equals(-1, vim.fn.foldclosed(1))
       end)
     end)
 


### PR DESCRIPTION
Adds an opt-in `view.inline.fold_unchanged` setting for `diff1_inline`, using the context from `diffopt` and the configured `view.foldlevel`.

This uses `foldmethod=expr` instead of manual folds so edits and renderer repaints can recompute fold boundaries from the current hunks. Pure-deletion anchors stay at fold level 0, which keeps their deleted `virt_lines` visible.

Tests:
- inline renderer, config, and layout specs pass
- config schema check passes
- full suite has 10 existing environment failures because `jj` and `hg` are not installed